### PR TITLE
fix(ci): make E2E job green by aligning Playwright and React versions

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -29,7 +29,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.10",
-    "react": "^19.2.3",
+    "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.9",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@eslint/js": "9.33.0",
-    "@playwright/test": "^1.54.2",
+    "@playwright/test": "1.55.1",
     "@types/node": "^25.9.1",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: 9.33.0
         version: 9.33.0
       '@playwright/test':
-        specifier: ^1.54.2
-        version: 1.54.2
+        specifier: 1.55.1
+        version: 1.55.1
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -101,11 +101,11 @@ importers:
         specifier: ^8.5.10
         version: 8.5.15
       react:
-        specifier: ^19.2.3
-        version: 19.2.3
+        specifier: ^19.2.7
+        version: 19.2.7
       react-dom:
         specifier: ^19.2.7
-        version: 19.2.7(react@19.2.3)
+        version: 19.2.7(react@19.2.7)
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
@@ -234,7 +234,7 @@ importers:
         version: 8.6.14(storybook@8.6.17(prettier@3.8.3))
       '@storybook/blocks':
         specifier: ^8.6.14
-        version: 8.6.14(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(storybook@8.6.17(prettier@3.8.3))
+        version: 8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.3)(storybook@8.6.17(prettier@3.8.3))
       '@storybook/builder-vite':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.17(prettier@3.8.3))(vite@5.4.21(@types/node@25.9.1)(lightningcss@1.30.1))
@@ -1379,8 +1379,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.54.2':
-    resolution: {integrity: sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==}
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4680,6 +4680,10 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
@@ -6437,11 +6441,11 @@ snapshots:
 
   '@mdn/browser-compat-data@4.2.1': {}
 
-  '@mdx-js/react@3.1.0(@types/react@19.2.7)(react@19.2.3)':
+  '@mdx-js/react@3.1.0(@types/react@19.2.7)(react@19.2.7)':
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.7
-      react: 19.2.3
+      react: 19.2.7
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6493,9 +6497,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.54.2':
+  '@playwright/test@1.55.1':
     dependencies:
-      playwright: 1.54.2
+      playwright: 1.55.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -6635,12 +6639,12 @@ snapshots:
 
   '@storybook/addon-docs@8.6.14(@types/react@19.2.7)(storybook@8.6.17(prettier@3.8.3))':
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@19.2.7)(react@19.2.3)
-      '@storybook/blocks': 8.6.14(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(storybook@8.6.17(prettier@3.8.3))
+      '@mdx-js/react': 3.1.0(@types/react@19.2.7)(react@19.2.7)
+      '@storybook/blocks': 8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.3))
       '@storybook/csf-plugin': 8.6.14(storybook@8.6.17(prettier@3.8.3))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(storybook@8.6.17(prettier@3.8.3))
-      react: 19.2.3
-      react-dom: 19.2.7(react@19.2.3)
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.3))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 8.6.17(prettier@3.8.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -6713,14 +6717,23 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.17(prettier@3.8.3)
 
-  '@storybook/blocks@8.6.14(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(storybook@8.6.17(prettier@3.8.3))':
+  '@storybook/blocks@8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.3)(storybook@8.6.17(prettier@3.8.3))':
     dependencies:
-      '@storybook/icons': 1.4.0(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
+      '@storybook/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.3)
       storybook: 8.6.17(prettier@3.8.3)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.3
-      react-dom: 19.2.7(react@19.2.3)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@storybook/blocks@8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.3))':
+    dependencies:
+      '@storybook/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 8.6.17(prettier@3.8.3)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@storybook/builder-vite@8.6.14(storybook@8.6.17(prettier@3.8.3))(vite@5.4.21(@types/node@25.9.1)(lightningcss@1.30.1))':
     dependencies:
@@ -6762,10 +6775,15 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.4.0(react-dom@19.2.7(react@19.2.3))(react@19.2.3)':
+  '@storybook/icons@1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.3)':
     dependencies:
       react: 19.2.3
-      react-dom: 19.2.7(react@19.2.3)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@storybook/icons@1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@storybook/instrumenter@8.6.14(storybook@8.6.17(prettier@3.8.3))':
     dependencies:
@@ -6781,10 +6799,10 @@ snapshots:
     dependencies:
       storybook: 8.6.17(prettier@3.8.3)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.7(react@19.2.3))(react@19.2.3)(storybook@8.6.17(prettier@3.8.3))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@8.6.17(prettier@3.8.3))':
     dependencies:
-      react: 19.2.3
-      react-dom: 19.2.7(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 8.6.17(prettier@3.8.3)
 
   '@storybook/test@8.6.14(storybook@8.6.17(prettier@3.8.3))':
@@ -10271,6 +10289,11 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
@@ -10278,6 +10301,8 @@ snapshots:
   react-refresh@0.17.0: {}
 
   react@19.2.3: {}
+
+  react@19.2.7: {}
 
   read-cache@1.0.0:
     dependencies:


### PR DESCRIPTION
## Problem

The **E2E Tests (Optional)** job on `main` fails (shows red although `continue-on-error: true`). It fails with `Error: No tests found` on `tests/e2e/demo.spec.ts`, and once discovery is fixed the demo app renders blank so every test times out.

Two root causes, both dependency version mismatches:

### 1. "No tests found" — duplicate Playwright versions
Root `package.json` pinned both `@playwright/test@^1.54.2` and a standalone `playwright@1.55.1`. The `playwright@1.55.1` bin ran the suite while `@playwright/test@1.54.2` loaded its own transitive `playwright@1.54.2`, so `test.describe()` ran against a different module instance:

> Playwright Test did not expect test.describe() to be called here … You have two different versions of @playwright/test.

Playwright then reported `No tests found` (0 tests). Fix: pin `@playwright/test` to `1.55.1` to match, collapsing to a single version.

### 2. Blank render — mismatched React / React-DOM
`apps/demo` pinned `react@^19.2.3` with `react-dom@^19.2.7`. React throws `Incompatible React versions` at mount, so `#root` stays empty and every DOM assertion times out. Fix: align `react` to `^19.2.7`.

## Fix
- `package.json`: `@playwright/test` `^1.54.2` -> `1.55.1`
- `apps/demo/package.json`: `react` `^19.2.3` -> `^19.2.7`
- `pnpm-lock.yaml`: regenerated (single `@playwright/test`/`playwright` at 1.55.1; `react`/`react-dom` both 19.2.7)

No test or Playwright-config changes were needed — the existing `demo.spec.ts` assertions all match the current demo app once it renders.

## Verification (local)
- `playwright test --list`: **45 tests** discovered (was **0**).
- Full suite: **45/45 passed** across chromium, firefox, webkit, Mobile Chrome, Mobile Safari (29.7s).
- `pnpm install --frozen-lockfile` passes (CI install mode).

https://claude.ai/code/session_01XsciE5KjxtMrHimxWxBVFS