### PR TITLE
fix(ci): repair invalid YAML in npm-publish release-notes step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -202,44 +202,35 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ inputs.tag }}"
-          
+          NOW="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+
           # Check if release already exists
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, updating with npm publish status..."
-            
+
             CURRENT_BODY=$(gh release view "$TAG" --json body -q .body)
-            
-            NEW_BODY="$CURRENT_BODY
+            NEW_BODY=$(printf '%s\n\n## 📦 NPM Publishing\n\nPackages have been published to npm: https://www.npmjs.com/org/glaze\n\nPublished at: %s\n' "$CURRENT_BODY" "$NOW")
 
-## 📦 NPM Publishing
-
-Packages have been published to npm: https://www.npmjs.com/org/glaze
-
-Published at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-            
             gh release edit "$TAG" --notes "$NEW_BODY"
           else
             echo "Creating new release for $TAG..."
-            
+
+            PKG_LIST=$(for pkg in packages/*/package.json; do
+              if [ -f "$pkg" ]; then
+                PKG_NAME=$(jq -r '.name' "$pkg")
+                PKG_VERSION=$(jq -r '.version' "$pkg")
+                PKG_PRIVATE=$(jq -r '.private // false' "$pkg")
+                if [ "$PKG_PRIVATE" != "true" ]; then
+                  echo "- [$PKG_NAME@$PKG_VERSION](https://www.npmjs.com/package/$PKG_NAME)"
+                fi
+              fi
+            done)
+            NOTES=$(printf '## 📦 NPM Packages\n\nThe following packages have been published to npm:\n\n%s\n\nPublished at: %s\n' "$PKG_LIST" "$NOW")
+
             # Create release with auto-generated notes
             gh release create "$TAG" \
               --title "Release $TAG" \
-              --notes "## 📦 NPM Packages
-
-The following packages have been published to npm:
-
-$(for pkg in packages/*/package.json; do
-  if [ -f "$pkg" ]; then
-    PKG_NAME=$(jq -r '.name' "$pkg")
-    PKG_VERSION=$(jq -r '.version' "$pkg")
-    PKG_PRIVATE=$(jq -r '.private // false' "$pkg")
-    if [ "$PKG_PRIVATE" != "true" ]; then
-      echo "- [$PKG_NAME@$PKG_VERSION](https://www.npmjs.com/package/$PKG_NAME)"
-    fi
-  fi
-done)
-
-Published at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+              --notes "$NOTES"
           fi
 
       - name: Post-publish summary


### PR DESCRIPTION
## Problem

`npm-publish` (`.github/workflows/npm-publish.yml`) is red on `main`. Every push produces a **0-second failed run with zero jobs** — GitHub's "This run likely failed because of a workflow file issue." The workflow itself only triggers on `release`/`workflow_dispatch`, but GitHub still validates it on every push and flags the syntax error.

## Root cause

The **Create GitHub Release Notes** step embedded multi-line bash double-quoted strings whose content lines sat at **column 0**:

```
            NEW_BODY="$CURRENT_BODY

## 📦 NPM Publishing            <- column 0

Packages have been published... <- column 0
...
$(for pkg in packages/*/package.json; do
...
```

Inside a `run: |` block scalar, any line less-indented than the block terminates the scalar, so the parser falls out of the step and the whole file fails to compile. `actionlint` pinpoints it:

```
.github/workflows/npm-publish.yml:224:12: could not parse as YAML: did not find expected key
```

Because the file doesn't compile, no jobs run and the check is reported as failed on every push.

Note: this is **not** an npm OIDC / ENEEDAUTH / trusted-publisher issue. This workflow is token-based (`NPM_TOKEN`) and already sets `registry-url`. The only defect is the YAML syntax error.

## Fix

Rebuild the release notes using `printf` and a pre-computed `PKG_LIST` variable so every line stays within the block-scalar indentation. Markdown output is byte-for-byte equivalent. `actionlint` now passes with no errors.

https://claude.ai/code/session_01T68jn2UbNWLE178iorAKtC